### PR TITLE
Fix for the CVE-2022-0155 | Cookie expose issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -355,10 +355,6 @@ RedirectableRequest.prototype._processResponse = function (response) {
       removeMatchingHeaders(/^content-/i, this._options.headers);
     }
 
-    // Drop the Host header, as the redirect might lead to a different host
-    var previousHostName = removeMatchingHeaders(/^host$/i, this._options.headers) ||
-      url.parse(this._currentUrl).hostname;
-
     // Create the redirected request
     var redirectUrl = url.resolve(this._currentUrl, location);
     debug("redirecting to", redirectUrl);
@@ -366,9 +362,16 @@ RedirectableRequest.prototype._processResponse = function (response) {
     var redirectUrlParts = url.parse(redirectUrl);
     Object.assign(this._options, redirectUrlParts);
 
-    // Drop the Authorization header if redirecting to another host
-    if (redirectUrlParts.hostname !== previousHostName) {
-      removeMatchingHeaders(/^authorization$/i, this._options.headers);
+    var currentUrlParts = url.parse(this._currentUrl);
+
+    var currentHost = removeMatchingHeaders(/^host$/i, this._options.headers) || currentUrlParts.host;
+    // Drop confidential headers when redirecting to a less secure protocol
+    // or to a different domain that is not a superdomain
+    if (
+      (redirectUrlParts.protocol !== currentUrlParts.protocol && redirectUrlParts.protocol !== "https:") ||
+      (redirectUrlParts.host !== currentHost && !isSubdomain(redirectUrlParts.host, currentHost))
+    ) {
+      removeMatchingHeaders(/^(?:(?:proxy-)?authorization|cookie)$/i, this._options.headers);
     }
 
     // Evaluate the beforeRedirect callback
@@ -506,6 +509,16 @@ function removeMatchingHeaders(regex, headers) {
     }
   }
   return lastValue;
+}
+
+function isString(value) {
+  return typeof value === "string" || value instanceof String;
+}
+
+function isSubdomain(subdomain, domain) {
+  assert(isString(subdomain) && isString(domain));
+  var dot = subdomain.length - domain.length - 1;
+  return dot > 0 && subdomain[dot] === "." && subdomain.endsWith(domain);
 }
 
 function createErrorType(code, defaultMessage) {

--- a/test/test.js
+++ b/test/test.js
@@ -268,9 +268,9 @@ describe("follow-redirects", function () {
 
     app.get("/a", function (req, res) {
       // Explictly send response with invalid Location header
-      res.socket.write("HTTP/1.1 301 Moved Permanently\n");
-      res.socket.write("Location: http://смольный-институт.рф\n");
-      res.socket.write("\n");
+      res.socket.write("HTTP/1.1 301 Moved Permanently\r\n");
+      res.socket.write("Location: http://смольный-институт.рф\r\n");
+      res.socket.write("\r\n");
       res.socket.end();
     });
 
@@ -289,9 +289,9 @@ describe("follow-redirects", function () {
 
   it("emits an error when the request fails for another reason", function () {
     app.get("/a", function (req, res) {
-      res.socket.write("HTTP/1.1 301 Moved Permanently\n");
-      res.socket.write("Location: other\n");
-      res.socket.write("\n");
+      res.socket.write("HTTP/1.1 301 Moved Permanently\r\n");
+      res.socket.write("Location: other\r\n");
+      res.socket.write("\r\n");
       res.socket.end();
     });
 
@@ -1208,6 +1208,29 @@ describe("follow-redirects", function () {
   });
 
   describe("when the client passes an Authorization header", function () {
+    const header = "Authorization";
+    const headerValue = "the header value";
+    it("ignores it when null", function () {
+      app.get("/a", redirectsTo(302, "http://localhost:3600/b"));
+      app.get("/b", function (req, res) {
+        res.end(JSON.stringify(req.headers));
+      });
+      var opts = url.parse("http://127.0.0.1:3600/a");
+      opts.headers = { host: "localhost" };
+      opts.headers[header] = null;
+      return server.start(app)
+        .then(asPromise(function (resolve, reject) {
+          http.get(opts, resolve).on("error", reject);
+        }))
+        .then(asPromise(function (resolve, reject, res) {
+          res.pipe(concat({ encoding: "string" }, resolve)).on("error", reject);
+        }))
+        .then(function (str) {
+          var body = JSON.parse(str);
+          assert.equal(body.host, "localhost:3600");
+          assert.equal(body[header.toLowerCase()], undefined);
+        });
+    });
     it("keeps the header when redirected to the same host", function () {
       app.get("/a", redirectsTo(302, "/b"));
       app.get("/b", function (req, res) {
@@ -1215,9 +1238,8 @@ describe("follow-redirects", function () {
       });
 
       var opts = url.parse("http://localhost:3600/a");
-      opts.headers = {
-        authorization: "bearer my-token-1234",
-      };
+      opts.headers = {};
+      opts.headers[header] = headerValue;
 
       return server.start(app)
         .then(asPromise(function (resolve, reject) {
@@ -1229,7 +1251,7 @@ describe("follow-redirects", function () {
         .then(function (str) {
           var body = JSON.parse(str);
           assert.equal(body.host, "localhost:3600");
-          assert.equal(body.authorization, "bearer my-token-1234");
+          assert.equal(body[header.toLowerCase()], headerValue);
         });
     });
 
@@ -1240,10 +1262,8 @@ describe("follow-redirects", function () {
       });
 
       var opts = url.parse("http://127.0.0.1:3600/a");
-      opts.headers = {
-        host: "localhost",
-        authorization: "bearer my-token-1234",
-      };
+      opts.headers = { host: "localhost:3600" };
+      opts.headers[header] = headerValue;
 
       return server.start(app)
         .then(asPromise(function (resolve, reject) {
@@ -1255,7 +1275,7 @@ describe("follow-redirects", function () {
         .then(function (str) {
           var body = JSON.parse(str);
           assert.equal(body.host, "localhost:3600");
-          assert.equal(body.authorization, "bearer my-token-1234");
+          assert.equal(body[header.toLowerCase()], headerValue);
         });
     });
 
@@ -1266,9 +1286,8 @@ describe("follow-redirects", function () {
       });
 
       var opts = url.parse("http://localhost:3600/a");
-      opts.headers = {
-        authorization: "bearer my-token-1234",
-      };
+      opts.headers = {};
+      opts.headers[header] = headerValue;
 
       return server.start(app)
         .then(asPromise(function (resolve, reject) {
@@ -1280,7 +1299,7 @@ describe("follow-redirects", function () {
         .then(function (str) {
           var body = JSON.parse(str);
           assert.equal(body.host, "127.0.0.1:3600");
-          assert.equal(body.authorization, undefined);
+          assert.equal(body[header.toLowerCase()], undefined);
         });
     });
 
@@ -1291,10 +1310,8 @@ describe("follow-redirects", function () {
       });
 
       var opts = url.parse("http://127.0.0.1:3600/a");
-      opts.headers = {
-        host: "localhost",
-        authorization: "bearer my-token-1234",
-      };
+      opts.headers = { host: "localhost:3600" };
+      opts.headers[header] = headerValue;
 
       return server.start(app)
         .then(asPromise(function (resolve, reject) {
@@ -1306,7 +1323,127 @@ describe("follow-redirects", function () {
         .then(function (str) {
           var body = JSON.parse(str);
           assert.equal(body.host, "127.0.0.1:3600");
-          assert.equal(body.authorization, undefined);
+          assert.equal(body[header.toLowerCase()], undefined);
+        });
+    });
+  });
+
+  describe("when the client passes a Cookie header", function () {
+    const header = "Cookie";
+    const headerValue = "the header value";
+    it("ignores it when null", function () {
+      app.get("/a", redirectsTo(302, "http://localhost:3600/b"));
+      app.get("/b", function (req, res) {
+        res.end(JSON.stringify(req.headers));
+      });
+      var opts = url.parse("http://127.0.0.1:3600/a");
+      opts.headers = { host: "localhost" };
+      opts.headers[header] = null;
+      return server.start(app)
+        .then(asPromise(function (resolve, reject) {
+          http.get(opts, resolve).on("error", reject);
+        }))
+        .then(asPromise(function (resolve, reject, res) {
+          res.pipe(concat({ encoding: "string" }, resolve)).on("error", reject);
+        }))
+        .then(function (str) {
+          var body = JSON.parse(str);
+          assert.equal(body.host, "localhost:3600");
+          assert.equal(body[header.toLowerCase()], undefined);
+        });
+    });
+    it("keeps the header when redirected to the same host", function () {
+      app.get("/a", redirectsTo(302, "/b"));
+      app.get("/b", function (req, res) {
+        res.end(JSON.stringify(req.headers));
+      });
+
+      var opts = url.parse("http://localhost:3600/a");
+      opts.headers = {};
+      opts.headers[header] = headerValue;
+
+      return server.start(app)
+        .then(asPromise(function (resolve, reject) {
+          http.get(opts, resolve).on("error", reject);
+        }))
+        .then(asPromise(function (resolve, reject, res) {
+          res.pipe(concat({ encoding: "string" }, resolve)).on("error", reject);
+        }))
+        .then(function (str) {
+          var body = JSON.parse(str);
+          assert.equal(body.host, "localhost:3600");
+          assert.equal(body[header.toLowerCase()], headerValue);
+        });
+    });
+
+    it("keeps the header when redirected to the same host via header", function () {
+      app.get("/a", redirectsTo(302, "http://localhost:3600/b"));
+      app.get("/b", function (req, res) {
+        res.end(JSON.stringify(req.headers));
+      });
+
+      var opts = url.parse("http://127.0.0.1:3600/a");
+      opts.headers = { host: "localhost:3600" };
+      opts.headers[header] = headerValue;
+
+      return server.start(app)
+        .then(asPromise(function (resolve, reject) {
+          http.get(opts, resolve).on("error", reject);
+        }))
+        .then(asPromise(function (resolve, reject, res) {
+          res.pipe(concat({ encoding: "string" }, resolve)).on("error", reject);
+        }))
+        .then(function (str) {
+          var body = JSON.parse(str);
+          assert.equal(body.host, "localhost:3600");
+          assert.equal(body[header.toLowerCase()], headerValue);
+        });
+    });
+
+    it("drops the header when redirected to a different host", function () {
+      app.get("/a", redirectsTo(302, "http://127.0.0.1:3600/b"));
+      app.get("/b", function (req, res) {
+        res.end(JSON.stringify(req.headers));
+      });
+
+      var opts = url.parse("http://localhost:3600/a");
+      opts.headers = {};
+      opts.headers[header] = headerValue;
+
+      return server.start(app)
+        .then(asPromise(function (resolve, reject) {
+          http.get(opts, resolve).on("error", reject);
+        }))
+        .then(asPromise(function (resolve, reject, res) {
+          res.pipe(concat({ encoding: "string" }, resolve)).on("error", reject);
+        }))
+        .then(function (str) {
+          var body = JSON.parse(str);
+          assert.equal(body.host, "127.0.0.1:3600");
+          assert.equal(body[header.toLowerCase()], undefined);
+        });
+    });
+
+    it("drops the header when redirected from a different host via header", function () {
+      app.get("/a", redirectsTo(302, "http://127.0.0.1:3600/b"));
+      app.get("/b", function (req, res) {
+        res.end(JSON.stringify(req.headers));
+      });
+
+      var opts = url.parse("http://127.0.0.1:3600/a");
+      opts.headers = { host: "localhost:3600" };
+      opts.headers[header] = headerValue;
+      return server.start(app)
+        .then(asPromise(function (resolve, reject) {
+          http.get(opts, resolve).on("error", reject);
+        }))
+        .then(asPromise(function (resolve, reject, res) {
+          res.pipe(concat({ encoding: "string" }, resolve)).on("error", reject);
+        }))
+        .then(function (str) {
+          var body = JSON.parse(str);
+          assert.equal(body.host, "127.0.0.1:3600");
+          assert.equal(body[header.toLowerCase()], undefined);
         });
     });
   });


### PR DESCRIPTION
As part of the fix:

- Added strict regex for removing the security headers when redirecting between hosts and protocols
- Added test cases to ensure the fix 